### PR TITLE
Got Movement Modifiers Working

### DIFF
--- a/Monster Mash/Monster Mash/Assets/Editor/BaseAttackDrawer.cs
+++ b/Monster Mash/Monster Mash/Assets/Editor/BaseAttackDrawer.cs
@@ -1,0 +1,124 @@
+#if UNITY_EDITOR
+using UnityEditor;
+using UnityEngine;
+
+// Lets us change the neutral and heavy attacks on the monster part and have it change to the subclass in the editor. This lets us edit subclass vars in the editor
+[CustomPropertyDrawer(typeof(NeutralAttack), true)]
+[CustomPropertyDrawer(typeof(HeavyAttack), true)]
+public class BaseAttackDrawer : PropertyDrawer
+{
+    public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+    {
+        EditorGUI.BeginProperty(position, label, property);
+
+        float y = position.y;
+        float lineHeight = EditorGUIUtility.singleLineHeight;
+        float spacing = 4f;
+
+        // Get the actual attack instance
+        BaseAttack baseAttack = property.managedReferenceValue as BaseAttack;
+
+        if (baseAttack == null)
+        {
+            EditorGUI.LabelField(position, "Null Base Attack");
+            EditorGUI.EndProperty();
+            return;
+        }
+
+        // Get enum type and value depending on subclass type
+        System.Enum currentEnum = null;
+        if (baseAttack is NeutralAttack neutral)
+        {
+            currentEnum = neutral.Attack;
+        }
+        else if (baseAttack is HeavyAttack heavy)
+        {
+            currentEnum = heavy.Attack;
+        }
+
+        if (currentEnum == null)
+        {
+            EditorGUI.LabelField(position, "Unknown Attack Enum");
+            EditorGUI.EndProperty();
+            return;
+        }
+
+        // Draw the enum popup manually
+        Rect enumRect = new Rect(position.x, y, position.width, lineHeight);
+        EditorGUI.BeginChangeCheck();
+
+        System.Enum newEnum = EditorGUI.EnumPopup(enumRect, "Attack", currentEnum);
+        y += lineHeight + spacing;
+
+        if (EditorGUI.EndChangeCheck())
+        {
+            // Create a new subclass instance with the new enum selected
+            BaseAttack newAttack = null;
+
+            if (baseAttack is NeutralAttack neutralAttack)
+            {
+                neutralAttack.Attack = (NeutralAttack.AttackType)newEnum;
+                newAttack = neutralAttack.GetAttack();
+                if (newAttack != null)
+                    ((NeutralAttack)newAttack).Attack = (NeutralAttack.AttackType)newEnum;
+            }
+            else if (baseAttack is HeavyAttack heavyAttack)
+            {
+                heavyAttack.Attack = (HeavyAttack.HeavyAttackType)newEnum;
+                newAttack = heavyAttack.GetAttack();
+                if (newAttack != null)
+                    ((HeavyAttack)newAttack).Attack = (HeavyAttack.HeavyAttackType)newEnum;
+            }
+
+            if (newAttack != null)
+            {
+                property.managedReferenceValue = newAttack;
+                property.serializedObject.ApplyModifiedProperties();
+            }
+
+            EditorGUI.EndProperty();
+            return; // We return early here because the instance changed, we redraw next frame
+        }
+
+        // Draw the rest of the fields
+        SerializedProperty iterator = property.Copy();
+        SerializedProperty endProperty = iterator.GetEndProperty();
+        bool enterChildren = true;
+
+        while (iterator.NextVisible(enterChildren) && !SerializedProperty.EqualContents(iterator, endProperty))
+        {
+            // Skip the base field since we drew the enum manually
+            if (iterator.name == "Attack")
+                continue;
+
+            float height = EditorGUI.GetPropertyHeight(iterator, true);
+            Rect propRect = new Rect(position.x, y, position.width, height);
+            EditorGUI.PropertyField(propRect, iterator, true);
+            y += height + spacing;
+            enterChildren = false;
+        }
+
+        EditorGUI.EndProperty();
+    }
+
+    public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+    {
+        float height = EditorGUIUtility.singleLineHeight + 4f;
+
+        SerializedProperty iterator = property.Copy();
+        SerializedProperty endProperty = iterator.GetEndProperty();
+        bool enterChildren = true;
+
+        while (iterator.NextVisible(enterChildren) && !SerializedProperty.EqualContents(iterator, endProperty))
+        {
+            if (iterator.name == "Attack")
+                continue;
+
+            height += EditorGUI.GetPropertyHeight(iterator, true) + 2f;
+            enterChildren = false;
+        }
+
+        return height;
+    }
+}
+#endif

--- a/Monster Mash/Monster Mash/Assets/Editor/BaseAttackDrawer.cs.meta
+++ b/Monster Mash/Monster Mash/Assets/Editor/BaseAttackDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4d6533e814436e34696814bbacfdb28b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/BaseAttack.cs
+++ b/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/BaseAttack.cs
@@ -6,10 +6,12 @@ using UnityEngine;
 public class TriggerAttackReleaseEventArgs : EventArgs
 {
     public Vector2 MovementModifier { get; set; }
+    public float ClipLength { get; set; }
 
-    public TriggerAttackReleaseEventArgs(Vector2 movementModifier)
+    public TriggerAttackReleaseEventArgs(Vector2 movementModifier, float clipLength)
     {
         MovementModifier = movementModifier;
+        ClipLength = clipLength;
     }
 }
 
@@ -43,7 +45,10 @@ public abstract class BaseAttack
 
     public virtual void triggerAttackRelease(NewMonsterPart monsterPartRef)
     {
-        OnAttackRelease?.Invoke(this, new TriggerAttackReleaseEventArgs(movementModifier));
+        // Get the attack animation length so that the movement is timed to the animation
+        float clipLength = monsterPartRef.myAnimator.GetCurrentAnimatorStateInfo(0).length;
+
+        OnAttackRelease?.Invoke(this, new TriggerAttackReleaseEventArgs(movementModifier, clipLength));
     }
 
     public virtual void CancelAttack()

--- a/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/BaseAttack.cs
+++ b/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/BaseAttack.cs
@@ -5,37 +5,29 @@ using UnityEngine;
 
 public class TriggerAttackReleaseEventArgs : EventArgs
 {
-    public Vector2 movementModifier { get; set; }
+    public Vector2 MovementModifier { get; set; }
 
     public TriggerAttackReleaseEventArgs(Vector2 movementModifier)
     {
-        this.movementModifier = movementModifier;
+        MovementModifier = movementModifier;
     }
 }
 
 
-public class BaseAttack
+public abstract class BaseAttack
 {
     protected NewMonsterPart monsterPartRef;
     protected MonsterPartVisual monsterPartVisualRef;
     [SerializeField] protected Vector2 movementModifier;
-    public static event EventHandler<TriggerAttackReleaseEventArgs> OnAttackRelease;
+    public event EventHandler<TriggerAttackReleaseEventArgs> OnAttackRelease;
 
     /// <summary>
     /// Used to grab public varables from the monster part script
     /// </summary>
     /// <param name="monsterPartRef">Instance of the monster part script</param>
-    public virtual void Init(NewMonsterPart monsterPartRef)
+    public virtual void Init(NewMonsterPart monsterPartRef, MonsterPartVisual monsterPartVisualRef)
     {
         this.monsterPartRef = monsterPartRef;
-    }
-
-    /// <summary>
-    /// Used to grab public varables from MonsterPartVisual
-    /// </summary>
-    /// <param name="monsterPartVisualRef">Instance of MonsterPartVisual</param>
-    public void Init(MonsterPartVisual monsterPartVisualRef)
-    {
         this.monsterPartVisualRef = monsterPartVisualRef;
     }
 

--- a/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/BaseAttack.cs
+++ b/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/BaseAttack.cs
@@ -1,11 +1,25 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+
+public class TriggerAttackReleaseEventArgs : EventArgs
+{
+    public Vector2 movementModifier { get; set; }
+
+    public TriggerAttackReleaseEventArgs(Vector2 movementModifier)
+    {
+        this.movementModifier = movementModifier;
+    }
+}
+
 
 public class BaseAttack
 {
     protected NewMonsterPart monsterPartRef;
     protected MonsterPartVisual monsterPartVisualRef;
+    [SerializeField] protected Vector2 movementModifier;
+    public static event EventHandler<TriggerAttackReleaseEventArgs> OnAttackRelease;
 
     /// <summary>
     /// Used to grab public varables from the monster part script
@@ -37,7 +51,7 @@ public class BaseAttack
 
     public virtual void triggerAttackRelease(NewMonsterPart monsterPartRef)
     {
-
+        OnAttackRelease?.Invoke(this, new TriggerAttackReleaseEventArgs(movementModifier));
     }
 
     public virtual void CancelAttack()

--- a/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/Heavy Attacks/BeamHeavy.cs
+++ b/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/Heavy Attacks/BeamHeavy.cs
@@ -1,14 +1,11 @@
+using System;
 using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
+[Serializable]
 public class BeamHeavy : HeavyAttack
 {
-    public override void Init(NewMonsterPart monsterPartRef)
-    {
-        base.Init(monsterPartRef);
-        Attack = HeavyAttackType.Beam;
-    }
+
     public override void triggerHeavyAttackVisuals()
     {
         monsterPartVisualRef.heavyHitVFXManager.unleashBeamVisual();

--- a/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/Heavy Attacks/BoomerangHeavy.cs
+++ b/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/Heavy Attacks/BoomerangHeavy.cs
@@ -1,14 +1,8 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+using System;
 
+[Serializable]
 public class BoomerangHeavy : HeavyAttack
 {
-    public override void Init(NewMonsterPart monsterPartRef)
-    {
-        base.Init(monsterPartRef);
-        Attack = HeavyAttackType.Boomerang;
-    }
     public override void SetupVFX()
     {
         if (monsterPartVisualRef.heavyHitVFXHolder != null || monsterPartVisualRef.heavyDefaultSprayVFXHolder != null)

--- a/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/Heavy Attacks/GrappleHeavy.cs
+++ b/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/Heavy Attacks/GrappleHeavy.cs
@@ -1,14 +1,8 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+using System;
 
+[Serializable]
 public class GrappleHeavy : HeavyAttack
 {
-    public override void Init(NewMonsterPart monsterPartRef)
-    {
-        base.Init(monsterPartRef);
-        Attack = HeavyAttackType.Grapple;
-    }
     public override void heavyAttackPowerCalculation()
     {
         base.heavyAttackPowerCalculation();

--- a/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/Heavy Attacks/JabHeavy.cs
+++ b/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/Heavy Attacks/JabHeavy.cs
@@ -14,6 +14,7 @@ public class JabHeavy : HeavyAttack
 
     public override void triggerAttackRelease(NewMonsterPart monsterPartRef)
     {
+        base.triggerAttackRelease(monsterPartRef);
         monsterPartRef.triggerJabOrSlashCollisionsOn();
     }
 

--- a/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/Heavy Attacks/JabHeavy.cs
+++ b/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/Heavy Attacks/JabHeavy.cs
@@ -1,14 +1,8 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+using System;
 
+[Serializable]
 public class JabHeavy : HeavyAttack
 {
-    public override void Init(NewMonsterPart monsterPartRef)
-    {
-        base.Init(monsterPartRef);
-        Attack = HeavyAttackType.Jab;
-    }
     public override void triggerHeavyAttackVisuals()
     {
         if (monsterPartRef.jabOrSlashLanded == false && monsterPartVisualRef.heavyMissVFXHolder != null)

--- a/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/Heavy Attacks/ProjectileHeavy.cs
+++ b/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/Heavy Attacks/ProjectileHeavy.cs
@@ -1,14 +1,8 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+using System;
 
+[Serializable]
 public class ProjectileHeavy : HeavyAttack
 {
-    public override void Init(NewMonsterPart monsterPartRef)
-    {
-        base.Init(monsterPartRef);
-        Attack = HeavyAttackType.Projectile;
-    }
     public override void SetupVFX()
     {
         if (monsterPartVisualRef.heavyHitVFXHolder != null || monsterPartVisualRef.heavyDefaultSprayVFXHolder != null)

--- a/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/Heavy Attacks/ReelHeavy.cs
+++ b/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/Heavy Attacks/ReelHeavy.cs
@@ -1,14 +1,8 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+using System;
 
+[Serializable]
 public class ReelHeavy : HeavyAttack
 {
-    public override void Init(NewMonsterPart monsterPartRef)
-    {
-        base.Init(monsterPartRef);
-        Attack = HeavyAttackType.Reel;
-    }
     public override void triggerHeavyAttackVisuals()
     {
         if (!monsterPartRef.reelAttackLanded)

--- a/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/Heavy Attacks/SlashHeavy.cs
+++ b/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/Heavy Attacks/SlashHeavy.cs
@@ -23,6 +23,7 @@ public class SlashHeavy : HeavyAttack
     }
     public override void triggerAttackRelease(NewMonsterPart monsterPartRef)
     {
+        base.triggerAttackRelease(monsterPartRef);
         monsterPartRef.triggerJabOrSlashCollisionsOn();
     }
 

--- a/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/Heavy Attacks/SlashHeavy.cs
+++ b/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/Heavy Attacks/SlashHeavy.cs
@@ -1,14 +1,8 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+using System;
 
+[Serializable]
 public class SlashHeavy : HeavyAttack
 {
-    public override void Init(NewMonsterPart monsterPartRef)
-    {
-        base.Init(monsterPartRef);
-        Attack = HeavyAttackType.Slash;
-    }
     public override void triggerHeavyAttackVisuals()
     {
         if (monsterPartRef.jabOrSlashLanded == false && monsterPartVisualRef.heavyMissVFXHolder != null)

--- a/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/Heavy Attacks/SprayHeavy.cs
+++ b/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/Heavy Attacks/SprayHeavy.cs
@@ -1,14 +1,8 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+using System;
 
+[Serializable]
 public class SprayHeavy : HeavyAttack
 {
-    public override void Init(NewMonsterPart monsterPartRef)
-    {
-        base.Init(monsterPartRef);
-        Attack = HeavyAttackType.Spray;
-    }
     public override void SetupVFX()
     {
         if (monsterPartVisualRef.heavyHitVFXHolder != null || monsterPartVisualRef.heavyDefaultSprayVFXHolder != null)

--- a/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/HeavyAttack.cs
+++ b/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/HeavyAttack.cs
@@ -30,7 +30,7 @@ public class HeavyAttack : BaseAttack
         Charging,
         SelfExploding,
     }
-
+    // a property drawer relies on this var using string lookup. Please do not change the var name or the property drawer will stop working
     public HeavyAttackType Attack;
 
 
@@ -38,16 +38,15 @@ public class HeavyAttack : BaseAttack
     {
         return Attack switch
         {
-            HeavyAttackType.None => new HeavyAttack(),
-            HeavyAttackType.Jab => new JabHeavy(),
-            HeavyAttackType.Slash => new SlashHeavy(),
-            HeavyAttackType.Spray => new SprayHeavy(),
-            HeavyAttackType.Projectile => new ProjectileHeavy(),
-            HeavyAttackType.Beam => new BeamHeavy(),
-            HeavyAttackType.Reel => new ReelHeavy(),
-            HeavyAttackType.Grapple => new GrappleHeavy(),
-            HeavyAttackType.Boomerang => new BoomerangHeavy(),
-            _ => new HeavyAttack()
+            HeavyAttackType.Jab => new JabHeavy { Attack = HeavyAttackType.Jab},
+            HeavyAttackType.Slash => new SlashHeavy { Attack = HeavyAttackType.Slash},
+            HeavyAttackType.Spray => new SprayHeavy { Attack = HeavyAttackType.Spray},
+            HeavyAttackType.Projectile => new ProjectileHeavy { Attack = HeavyAttackType.Projectile},
+            HeavyAttackType.Beam => new BeamHeavy { Attack = HeavyAttackType.Beam},
+            HeavyAttackType.Reel => new ReelHeavy { Attack = HeavyAttackType.Reel},
+            HeavyAttackType.Grapple => new GrappleHeavy { Attack = HeavyAttackType.Grapple},
+            HeavyAttackType.Boomerang => new BoomerangHeavy { Attack = HeavyAttackType.Boomerang},
+            _ => new HeavyAttack { Attack = HeavyAttackType.None}
         };
     }
 

--- a/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/Neutral Attacks/BoomerangNeutral.cs
+++ b/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/Neutral Attacks/BoomerangNeutral.cs
@@ -1,14 +1,8 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+using System;
 
+[Serializable]
 public class BoomerangNeutral : NeutralAttack
 {
-    public override void Init(NewMonsterPart monsterPartRef)
-    {
-        base.Init(monsterPartRef);
-        Attack = AttackType.Boomerang;
-    }
     public override void neutralAttackPowerCalculation()
     {
         base.neutralAttackPowerCalculation();

--- a/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/Neutral Attacks/JabNeutral.cs
+++ b/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/Neutral Attacks/JabNeutral.cs
@@ -22,6 +22,7 @@ public class JabNeutral : NeutralAttack
 
     public override void triggerAttackRelease(NewMonsterPart monsterPartRef)
     {
+        base.triggerAttackRelease(monsterPartRef);
         monsterPartRef.triggerJabOrSlashCollisionsOn();
     }
 

--- a/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/Neutral Attacks/JabNeutral.cs
+++ b/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/Neutral Attacks/JabNeutral.cs
@@ -1,15 +1,8 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+using System;
 
+[Serializable]
 public class JabNeutral : NeutralAttack
 {
-
-    public override void Init(NewMonsterPart monsterPartRef)
-    {
-        base.Init(monsterPartRef);
-        Attack = AttackType.Jab;
-    }
 
     public override void neutralAttackPowerCalculation()
     {

--- a/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/Neutral Attacks/ProjectileNeutral.cs
+++ b/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/Neutral Attacks/ProjectileNeutral.cs
@@ -1,14 +1,8 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+using System;
 
+[Serializable]
 public class ProjectileNeutral : NeutralAttack
 {
-    public override void Init(NewMonsterPart monsterPartRef)
-    {
-        base.Init(monsterPartRef);
-        Attack = AttackType.Projectile;
-    }
     public override void neutralAttackPowerCalculation()
     {
         base.neutralAttackPowerCalculation();

--- a/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/Neutral Attacks/SlashNeutral.cs
+++ b/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/Neutral Attacks/SlashNeutral.cs
@@ -21,6 +21,7 @@ public class SlashNeutral : NeutralAttack
 
     public override void triggerAttackRelease(NewMonsterPart monsterPartRef)
     {
+        base.triggerAttackRelease(monsterPartRef);
         monsterPartRef.triggerJabOrSlashCollisionsOn();
     }
 

--- a/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/Neutral Attacks/SlashNeutral.cs
+++ b/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/Neutral Attacks/SlashNeutral.cs
@@ -1,15 +1,8 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+using System;
 
+[Serializable]
 public class SlashNeutral : NeutralAttack
 {
-    public override void Init(NewMonsterPart monsterPartRef)
-    {
-        base.Init(monsterPartRef);
-        Attack = AttackType.Slash;
-    }
-
     public override void neutralAttackPowerCalculation()
     {
         base.neutralAttackPowerCalculation();

--- a/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/Neutral Attacks/SprayNeutral.cs
+++ b/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/Neutral Attacks/SprayNeutral.cs
@@ -1,15 +1,8 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+using System;
 
+[Serializable]
 public class SprayNeutral : NeutralAttack
 {
-    public override void Init(NewMonsterPart monsterPartRef)
-    {
-        base.Init(monsterPartRef);
-        Attack = AttackType.Spray;
-    }
-
     public override void neutralAttackPowerCalculation()
     {
         base.neutralAttackPowerCalculation();

--- a/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/NeutralAttack.cs
+++ b/Monster Mash/Monster Mash/Assets/Monster Parts/Attack Scripts/NeutralAttack.cs
@@ -22,20 +22,20 @@ public class NeutralAttack: BaseAttack
         AOE,
         Boomerang
     }
-
+    // a property drawer relies on this var using string lookup. Please do not change the var name or the property drawer will stop working
     public AttackType Attack;
 
+    // factory pattern to assign the subclass
     public NeutralAttack GetAttack()
     {
         return Attack switch
         {
-            AttackType.None => new NeutralAttack(), 
-            AttackType.Jab => new JabNeutral(),
-            AttackType.Slash => new SlashNeutral(),
-            AttackType.Spray => new SprayNeutral(),
-            AttackType.Projectile => new ProjectileNeutral(),
-            AttackType.Boomerang => new BoomerangNeutral(),
-            _ => new NeutralAttack(),
+            AttackType.Jab => new JabNeutral { Attack = AttackType.Jab},
+            AttackType.Slash => new SlashNeutral { Attack = AttackType.Slash},
+            AttackType.Spray => new SprayNeutral { Attack = AttackType.Spray},
+            AttackType.Projectile => new ProjectileNeutral { Attack = AttackType.Projectile},
+            AttackType.Boomerang => new BoomerangNeutral { Attack = AttackType.Boomerang},
+            _ => new NeutralAttack { Attack = AttackType.None},
         };
     }
 

--- a/Monster Mash/Monster Mash/Assets/Monster Parts/NewMonsterPart.cs
+++ b/Monster Mash/Monster Mash/Assets/Monster Parts/NewMonsterPart.cs
@@ -27,7 +27,18 @@ public class NewMonsterPart : MonoBehaviour
     //also because there is a pretty big oversight right now for "right" sided limbs that may end up being repositioned or rotated to act as a "left" sided limb
     //public enum WhichPart{ isArm, isLeg, isTail, isWing, isHead, isEye, isMouth, isTorso, isHorn, isDecor};
     //public WhichPart thisPart;
-    [Header("Monster Part Questionaire")]
+   
+#if UNITY_EDITOR
+    void OnValidate()
+    {
+        if (neutralAttack == null)
+            neutralAttack = new NeutralAttack();
+
+        if (heavyAttack == null)
+            heavyAttack = new HeavyAttack();
+    }
+#endif
+   [Header("Monster Part Questionaire")]
 
     public bool isArm;
     public bool isLeg;
@@ -61,8 +72,8 @@ public class NewMonsterPart : MonoBehaviour
     public bool slowedStatusEffect;
     public bool grabbedStatusEffect;
 
-    [Header("Neutral Attack Questionaire")]
-    public NeutralAttack neutralAttack;
+   [Header("Neutral Attack Questionaire")]
+   [SerializeReference] public NeutralAttack neutralAttack = new NeutralAttack();
 
     public Collider neutralCollider;
     public monsterPartReference neutralColliderReference;
@@ -77,7 +88,7 @@ public class NewMonsterPart : MonoBehaviour
 
     [Header("Heavy Attack Questionaire")]
 
-    public HeavyAttack heavyAttack;
+    [SerializeReference] public HeavyAttack heavyAttack = new HeavyAttack();
     //
     public Collider heavyCollider;
     public monsterPartReference heavyColliderReference;
@@ -151,14 +162,8 @@ public class NewMonsterPart : MonoBehaviour
 
         PartVisual = GetComponent<MonsterPartVisual>();
 
-        neutralAttack = neutralAttack.GetAttack();
-        heavyAttack = heavyAttack.GetAttack();
-
-        neutralAttack.Init(this);
-        heavyAttack.Init(this);
-
-        neutralAttack.Init(PartVisual);
-        heavyAttack.Init(PartVisual);
+        neutralAttack.Init(this, PartVisual);
+        heavyAttack.Init(this, PartVisual);
 
         attackSetupDone = true;
     }

--- a/Monster Mash/Monster Mash/Assets/Monster Parts/monsterAttackSystem.cs
+++ b/Monster Mash/Monster Mash/Assets/Monster Parts/monsterAttackSystem.cs
@@ -123,13 +123,16 @@ public class monsterAttackSystem : MonoBehaviour
     public GameObject floorCheck;
 
 
-    private void OnDisable()
+    private void OnDestroy()
     {
-        // the events are already unsubscribed in popoffmonsterpart() but this is just for safety in case the object is suddenely disabled for some reason.
+        // the events are already unsubscribed in popoffmonsterpart() but this is just for safety in case the object is suddenely distroyed for some reason.
         foreach (NewMonsterPart monsterPart in attackSlotMonsterParts)
         {
-            monsterPart.neutralAttack.OnAttackRelease -= myPlayer.ApplyMovementModifier;
-            monsterPart.heavyAttack.OnAttackRelease -= myPlayer.ApplyMovementModifier;
+            if (monsterPart != null)
+            {
+                monsterPart.neutralAttack.OnAttackRelease -= myPlayer.ApplyMovementModifier;
+                monsterPart.heavyAttack.OnAttackRelease -= myPlayer.ApplyMovementModifier;
+            }
         }
     }
 
@@ -389,11 +392,19 @@ public class monsterAttackSystem : MonoBehaviour
             allMonsterParts[i].triggerIdle();
         }
 
+       
         // connects all the attacking monster parts OnAttackrelease event to the player controller
         foreach (NewMonsterPart monsterPart in attackSlotMonsterParts)
         {
-            monsterPart.neutralAttack.OnAttackRelease += myPlayer.ApplyMovementModifier;
-            monsterPart.heavyAttack.OnAttackRelease += myPlayer.ApplyMovementModifier;
+            if (monsterPart != null)
+            {
+                // if we don't unsubscribe first then ApplyMovemnetModifer can be called multiple times for one action
+                monsterPart.neutralAttack.OnAttackRelease -= myPlayer.ApplyMovementModifier;
+                monsterPart.heavyAttack.OnAttackRelease -= myPlayer.ApplyMovementModifier;
+
+                monsterPart.neutralAttack.OnAttackRelease += myPlayer.ApplyMovementModifier;
+                monsterPart.heavyAttack.OnAttackRelease += myPlayer.ApplyMovementModifier;
+            }
         }
 
         myAnimator.SetBool("Idle Bounce Allowed", true);

--- a/Monster Mash/Monster Mash/Assets/Monster Parts/monsterAttackSystem.cs
+++ b/Monster Mash/Monster Mash/Assets/Monster Parts/monsterAttackSystem.cs
@@ -122,6 +122,18 @@ public class monsterAttackSystem : MonoBehaviour
     public SFXManager SFXManager;
     public GameObject floorCheck;
 
+
+    private void OnDisable()
+    {
+        // the events are already unsubscribed in popoffmonsterpart() but this is just for safety in case the object is suddenely disabled for some reason.
+        foreach (NewMonsterPart monsterPart in attackSlotMonsterParts)
+        {
+            monsterPart.neutralAttack.OnAttackRelease -= myPlayer.ApplyMovementModifier;
+            monsterPart.heavyAttack.OnAttackRelease -= myPlayer.ApplyMovementModifier;
+        }
+    }
+
+
     #region Monster Start Up
 
     public void connectNecessaryLocomotionComponents()
@@ -375,6 +387,13 @@ public class monsterAttackSystem : MonoBehaviour
             allMonsterParts[i].triggerAnimationOffsets();
             allMonsterParts[i].triggerCollisionLogic(); //collision logic must come after animation set up because animation set up includes projectile set up 
             allMonsterParts[i].triggerIdle();
+        }
+
+        // connects all the attacking monster parts OnAttackrelease event to the player controller
+        foreach (NewMonsterPart monsterPart in attackSlotMonsterParts)
+        {
+            monsterPart.neutralAttack.OnAttackRelease += myPlayer.ApplyMovementModifier;
+            monsterPart.heavyAttack.OnAttackRelease += myPlayer.ApplyMovementModifier;
         }
 
         myAnimator.SetBool("Idle Bounce Allowed", true);
@@ -2531,6 +2550,8 @@ public class monsterAttackSystem : MonoBehaviour
                 if (attackSlotMonsterParts[i] == partRemoved)
                 {
                     partRemoved.disconnectThisPart();
+                    partRemoved.neutralAttack.OnAttackRelease -= myPlayer.ApplyMovementModifier;
+                    partRemoved.heavyAttack.OnAttackRelease -= myPlayer.ApplyMovementModifier;
                     destructionPhysicsHelper.SetActive(true);
                     StartCoroutine(removeMonsterPartFromStage(attackSlotMonsterParts[i].gameObject));
                     //store some sort of parental and location data

--- a/Monster Mash/Monster Mash/Assets/Monster Parts/monsterAttackSystem.cs
+++ b/Monster Mash/Monster Mash/Assets/Monster Parts/monsterAttackSystem.cs
@@ -1983,6 +1983,8 @@ public class monsterAttackSystem : MonoBehaviour
         getOutOfLaunch();
     }
 
+    
+
     #endregion
 
     #region Reactions

--- a/Monster Mash/Monster Mash/Assets/Player Controller/playerController.cs
+++ b/Monster Mash/Monster Mash/Assets/Player Controller/playerController.cs
@@ -134,6 +134,17 @@ public class playerController : MonoBehaviour
         }
     }
 
+    private void OnEnable()
+    {
+        BaseAttack.OnAttackRelease += ApplyMovementModifier;
+    }
+
+    private void OnDisable()
+    {
+        BaseAttack.OnAttackRelease -= ApplyMovementModifier;
+        UnsubscribeActionMap();
+    }
+
     public void PlayerInputSetUp()
     {
         startingActionMap = playerInput.actions.FindActionMap("Starting Action Map");
@@ -149,10 +160,10 @@ public class playerController : MonoBehaviour
 
         switchActionMap("Monster Controls");
 
-        Subscribe();
+        SubscribeActionMap();
     }
 
-    void Subscribe()
+    void SubscribeActionMap()
     {
         playerInput.actions.FindActionMap("Monster Controls").FindAction("Left Stick").performed += OnLeftStick;
 
@@ -176,8 +187,9 @@ public class playerController : MonoBehaviour
         playerInput.actions.FindActionMap("Monster Controls").FindAction("Y").canceled += onButtonY;
     }
 
-    void Unsubscribe()
+    void UnsubscribeActionMap()
     {
+
         playerInput.actions.FindActionMap("Monster Controls").FindAction("Left Stick").performed -= OnLeftStick;
 
         playerInput.actions.FindActionMap("Monster Controls").FindAction("Left Stick").canceled -= OnLeftStick;
@@ -200,10 +212,7 @@ public class playerController : MonoBehaviour
         playerInput.actions.FindActionMap("Monster Controls").FindAction("Y").canceled -= onButtonY;
     }
 
-    private void OnDisable()
-    {
-        Unsubscribe();
-    }
+    
 
     public void switchActionMap(string newActionMap)
     {
@@ -2083,6 +2092,12 @@ public class playerController : MonoBehaviour
             myRigidbody.velocity = new Vector2(20 * directionModifier, myRigidbody.velocity.y);
         }
         */
+    }
+
+    // Listens for when an attack calls Trigger Attack Release
+    public void ApplyMovementModifier(object sender, TriggerAttackReleaseEventArgs eventArgs)
+    {
+        myRigidbody.AddForce(eventArgs.movementModifier, ForceMode2D.Impulse);
     }
 
     IEnumerator leapAttackForwardControl()

--- a/Monster Mash/Monster Mash/Assets/Player Controller/playerController.cs
+++ b/Monster Mash/Monster Mash/Assets/Player Controller/playerController.cs
@@ -2093,10 +2093,37 @@ public class playerController : MonoBehaviour
     // Listens for when an attack calls Trigger Attack Release
     public void ApplyMovementModifier(object sender, TriggerAttackReleaseEventArgs eventArgs)
     {
-        myRigidbody.AddForce(eventArgs.MovementModifier, ForceMode2D.Impulse);
+        Vector2 movementModifier = eventArgs.MovementModifier;
+
+        if (!facingRight)
+            movementModifier.x *= -1;
+
+        // using the animation clip length so that the movement duration matches the animation
+        StartCoroutine(ApplySmoothedMovementModifier(movementModifier, eventArgs.ClipLength));
     }
 
-    IEnumerator leapAttackForwardControl()
+    // smooths out the movement so that it is not instant and it looks a bit better
+    private IEnumerator ApplySmoothedMovementModifier(Vector2 totalOffset, float duration)
+    {
+        float elapsed = 0f;
+
+        while (elapsed < duration)
+        {
+            float delta = Time.fixedDeltaTime;
+            float previousT = elapsed / duration;
+            elapsed += delta;
+            float currentT = Mathf.Clamp01(elapsed / duration);
+
+            
+            Vector2 frameOffset = (currentT - previousT) * totalOffset;
+
+            myRigidbody.MovePosition(myRigidbody.position + frameOffset);
+            yield return new WaitForFixedUpdate();
+        }
+    }
+
+
+        IEnumerator leapAttackForwardControl()
     {
         yield return new WaitForSeconds(0.1f);
         myRigidbody.velocity = new Vector2(0, myRigidbody.velocity.y);

--- a/Monster Mash/Monster Mash/Assets/Player Controller/playerController.cs
+++ b/Monster Mash/Monster Mash/Assets/Player Controller/playerController.cs
@@ -134,14 +134,10 @@ public class playerController : MonoBehaviour
         }
     }
 
-    private void OnEnable()
-    {
-        BaseAttack.OnAttackRelease += ApplyMovementModifier;
-    }
+   
 
     private void OnDisable()
     {
-        BaseAttack.OnAttackRelease -= ApplyMovementModifier;
         UnsubscribeActionMap();
     }
 
@@ -2097,7 +2093,7 @@ public class playerController : MonoBehaviour
     // Listens for when an attack calls Trigger Attack Release
     public void ApplyMovementModifier(object sender, TriggerAttackReleaseEventArgs eventArgs)
     {
-        myRigidbody.AddForce(eventArgs.movementModifier, ForceMode2D.Impulse);
+        myRigidbody.AddForce(eventArgs.MovementModifier, ForceMode2D.Impulse);
     }
 
     IEnumerator leapAttackForwardControl()

--- a/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Arms/Arm 1.prefab
+++ b/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Arms/Arm 1.prefab
@@ -44949,7 +44949,7 @@ MonoBehaviour:
   slowedStatusEffect: 0
   grabbedStatusEffect: 0
   neutralAttack:
-    Attack: 1
+    rid: 8001967990336913525
   neutralCollider: {fileID: 9042840373748160034}
   neutralColliderReference: {fileID: 0}
   needsReloadNeutral: 0
@@ -44959,7 +44959,7 @@ MonoBehaviour:
   jabOrSlashLanded: 0
   neutralAttackHitAudioLibrary: []
   heavyAttack:
-    Attack: 1
+    rid: 8001967990336913409
   heavyCollider: {fileID: 2530626749398687388}
   heavyColliderReference: {fileID: 0}
   heavyMuzzle: {fileID: 0}
@@ -45001,6 +45001,19 @@ MonoBehaviour:
   reelAttackLanded: 0
   myIdleVFX: []
   referencesToIgnore: []
+  references:
+    version: 2
+    RefIds:
+    - rid: 8001967990336913409
+      type: {class: HeavyAttack, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
+        Attack: 0
+    - rid: 8001967990336913525
+      type: {class: NeutralAttack, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
+        Attack: 0
 --- !u!114 &1750710558831751638
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Arms/Arm 1.prefab
+++ b/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Arms/Arm 1.prefab
@@ -44959,7 +44959,7 @@ MonoBehaviour:
   jabOrSlashLanded: 0
   neutralAttackHitAudioLibrary: []
   heavyAttack:
-    rid: 8001967990336913409
+    rid: 8001968035020406788
   heavyCollider: {fileID: 2530626749398687388}
   heavyColliderReference: {fileID: 0}
   heavyMuzzle: {fileID: 0}
@@ -45004,15 +45004,15 @@ MonoBehaviour:
   references:
     version: 2
     RefIds:
-    - rid: 8001967990336913409
-      type: {class: HeavyAttack, ns: , asm: Assembly-CSharp}
-      data:
-        movementModifier: {x: 0, y: 0}
-        Attack: 0
     - rid: 8001968010203758640
       type: {class: JabNeutral, ns: , asm: Assembly-CSharp}
       data:
         movementModifier: {x: 5, y: 0}
+        Attack: 1
+    - rid: 8001968035020406788
+      type: {class: JabHeavy, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
         Attack: 1
 --- !u!114 &1750710558831751638
 MonoBehaviour:

--- a/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Arms/Arm 1.prefab
+++ b/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Arms/Arm 1.prefab
@@ -44949,7 +44949,7 @@ MonoBehaviour:
   slowedStatusEffect: 0
   grabbedStatusEffect: 0
   neutralAttack:
-    rid: 8001967990336913525
+    rid: 8001968010203758640
   neutralCollider: {fileID: 9042840373748160034}
   neutralColliderReference: {fileID: 0}
   needsReloadNeutral: 0
@@ -45009,11 +45009,11 @@ MonoBehaviour:
       data:
         movementModifier: {x: 0, y: 0}
         Attack: 0
-    - rid: 8001967990336913525
-      type: {class: NeutralAttack, ns: , asm: Assembly-CSharp}
+    - rid: 8001968010203758640
+      type: {class: JabNeutral, ns: , asm: Assembly-CSharp}
       data:
-        movementModifier: {x: 0, y: 0}
-        Attack: 0
+        movementModifier: {x: 5, y: 0}
+        Attack: 1
 --- !u!114 &1750710558831751638
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Arms/Arm 11.prefab
+++ b/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Arms/Arm 11.prefab
@@ -785,7 +785,7 @@ MonoBehaviour:
   slowedStatusEffect: 0
   grabbedStatusEffect: 0
   neutralAttack:
-    Attack: 0
+    rid: 8001968035020406809
   neutralCollider: {fileID: 0}
   neutralColliderReference: {fileID: 0}
   needsReloadNeutral: 0
@@ -794,47 +794,13 @@ MonoBehaviour:
   isReloadedHeavy: 1
   jabOrSlashLanded: 0
   neutralAttackHitAudioLibrary: []
-  jabHeavyAttack: 0
-  slashHeavyAttack: 0
-  sprayHeavyAttack: 0
-  projectileHeavyAttack: 0
-  beamHeavyAttack: 0
-  reelHeavyAttack: 0
-  grappleHeavyAttack: 0
-  boomerangHeavyAttack: 0
-  homingMissileHeavyAttack: 0
-  anvilHeavyAttack: 0
-  bowlingBallHeavyAttack: 0
-  gaseousHeavyAttack: 0
-  powerBoostingHeavyAttack: 0
-  shieldHeavyAttack: 0
-  reflectingHeavyAttack: 0
-  eatingHeavyAttack: 0
-  suctionHeavyAttack: 0
-  AOEHeavyAttack: 0
-  chargingHeavyAttack: 0
-  selfExplodingHeavyAttack: 0
-  heavyHitVFXHolder: {fileID: 0}
-  heavyForwardSwingVFXHolder: {fileID: 0}
-  heavyBackwardSwingVFXHolder: {fileID: 0}
-  heavyDownwardSwingVFXHolder: {fileID: 0}
-  heavyMissVFXHolder: {fileID: 0}
-  heavyDefaultSprayVFXHolder: {fileID: 0}
-  heavyStompVFXHolder: {fileID: 0}
+  heavyAttack:
+    rid: 8001968035020406810
   heavyCollider: {fileID: 0}
   heavyColliderReference: {fileID: 0}
   heavyMuzzle: {fileID: 0}
   needsReloadHeavy: 0
   reloadTimeHeavy: 1
-  chargeVisual: {fileID: 0}
-  heavyChargeVisual: {fileID: 0}
-  heavyAttackHitVFXArray: []
-  heavyAttackForwardSwingVFXArray: []
-  heavyAttackBackwardSwingVFXArray: []
-  heavyAttackDownwardSwingVFXArray: []
-  heavyAttackMissVFXArray: []
-  heavyAttackDefaultVFXArray: []
-  heavyStompVFXArray: []
   heavyAttackHitAudioLibrary: []
   isJointed: 1
   isRightSidedLimb: 0
@@ -868,6 +834,19 @@ MonoBehaviour:
   reelAttackLanded: 0
   myIdleVFX: []
   referencesToIgnore: []
+  references:
+    version: 2
+    RefIds:
+    - rid: 8001968035020406809
+      type: {class: NeutralAttack, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
+        Attack: 5
+    - rid: 8001968035020406810
+      type: {class: HeavyAttack, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
+        Attack: 14
 --- !u!114 &3292041790415763189
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1088,6 +1067,10 @@ MonoBehaviour:
     partRotation: {x: 0, y: 0, z: 0, w: 0}
     partScale: {x: 0, y: 0, z: 0}
     partPosition: {x: 0, y: 0, z: 0}
+    partButton: 0
+    palleteSwapIndex: 
+    partHexCode: 
+    isFlipped: 0
 --- !u!1 &4790002536095218571
 GameObject:
   m_ObjectHideFlags: 0

--- a/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Arms/Arm 12.prefab
+++ b/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Arms/Arm 12.prefab
@@ -110,7 +110,7 @@ MonoBehaviour:
   slowedStatusEffect: 0
   grabbedStatusEffect: 0
   neutralAttack:
-    Attack: 0
+    rid: 8001968035020406813
   neutralCollider: {fileID: 0}
   neutralColliderReference: {fileID: 0}
   needsReloadNeutral: 0
@@ -120,7 +120,7 @@ MonoBehaviour:
   jabOrSlashLanded: 0
   neutralAttackHitAudioLibrary: []
   heavyAttack:
-    Attack: 0
+    rid: 8001968035020406814
   heavyCollider: {fileID: 0}
   heavyColliderReference: {fileID: 0}
   heavyMuzzle: {fileID: 0}
@@ -159,6 +159,19 @@ MonoBehaviour:
   reelAttackLanded: 0
   myIdleVFX: []
   referencesToIgnore: []
+  references:
+    version: 2
+    RefIds:
+    - rid: 8001968035020406813
+      type: {class: SlashNeutral, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
+        Attack: 2
+    - rid: 8001968035020406814
+      type: {class: SlashHeavy, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
+        Attack: 2
 --- !u!114 &3763283894889006868
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -379,6 +392,10 @@ MonoBehaviour:
     partRotation: {x: 0, y: 0, z: 0, w: 0}
     partScale: {x: 0, y: 0, z: 0}
     partPosition: {x: 0, y: 0, z: 0}
+    partButton: 0
+    palleteSwapIndex: 
+    partHexCode: 
+    isFlipped: 0
 --- !u!1 &200811085674684452
 GameObject:
   m_ObjectHideFlags: 0

--- a/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Arms/Arm 15.prefab
+++ b/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Arms/Arm 15.prefab
@@ -1058,7 +1058,7 @@ MonoBehaviour:
   slowedStatusEffect: 0
   grabbedStatusEffect: 0
   neutralAttack:
-    Attack: 0
+    rid: 8001968035020406817
   neutralCollider: {fileID: 0}
   neutralColliderReference: {fileID: 0}
   needsReloadNeutral: 0
@@ -1068,7 +1068,7 @@ MonoBehaviour:
   jabOrSlashLanded: 0
   neutralAttackHitAudioLibrary: []
   heavyAttack:
-    Attack: 0
+    rid: 8001968035020406818
   heavyCollider: {fileID: 0}
   heavyColliderReference: {fileID: 0}
   heavyMuzzle: {fileID: 0}
@@ -1107,6 +1107,19 @@ MonoBehaviour:
   reelAttackLanded: 0
   myIdleVFX: []
   referencesToIgnore: []
+  references:
+    version: 2
+    RefIds:
+    - rid: 8001968035020406817
+      type: {class: SprayNeutral, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
+        Attack: 3
+    - rid: 8001968035020406818
+      type: {class: HeavyAttack, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
+        Attack: 13
 --- !u!114 &3612200419161604414
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1231,6 +1244,10 @@ MonoBehaviour:
     partRotation: {x: 0, y: 0, z: 0, w: 0}
     partScale: {x: 0, y: 0, z: 0}
     partPosition: {x: 0, y: 0, z: 0}
+    partButton: 0
+    palleteSwapIndex: 
+    partHexCode: 
+    isFlipped: 0
 --- !u!1 &6623776135738468033
 GameObject:
   m_ObjectHideFlags: 0

--- a/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Arms/Arm 5.prefab
+++ b/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Arms/Arm 5.prefab
@@ -859,7 +859,7 @@ MonoBehaviour:
   slowedStatusEffect: 0
   grabbedStatusEffect: 0
   neutralAttack:
-    Attack: 1
+    rid: 8001968035020406791
   neutralCollider: {fileID: 1131301108047581070}
   neutralColliderReference: {fileID: 0}
   needsReloadNeutral: 0
@@ -868,47 +868,13 @@ MonoBehaviour:
   isReloadedHeavy: 1
   jabOrSlashLanded: 0
   neutralAttackHitAudioLibrary: []
-  jabHeavyAttack: 0
-  slashHeavyAttack: 0
-  sprayHeavyAttack: 0
-  projectileHeavyAttack: 0
-  beamHeavyAttack: 0
-  reelHeavyAttack: 0
-  grappleHeavyAttack: 1
-  boomerangHeavyAttack: 0
-  homingMissileHeavyAttack: 0
-  anvilHeavyAttack: 0
-  bowlingBallHeavyAttack: 0
-  gaseousHeavyAttack: 0
-  powerBoostingHeavyAttack: 0
-  shieldHeavyAttack: 0
-  reflectingHeavyAttack: 0
-  eatingHeavyAttack: 0
-  suctionHeavyAttack: 0
-  AOEHeavyAttack: 0
-  chargingHeavyAttack: 0
-  selfExplodingHeavyAttack: 0
-  heavyHitVFXHolder: {fileID: 0}
-  heavyForwardSwingVFXHolder: {fileID: 0}
-  heavyBackwardSwingVFXHolder: {fileID: 0}
-  heavyDownwardSwingVFXHolder: {fileID: 0}
-  heavyMissVFXHolder: {fileID: 0}
-  heavyDefaultSprayVFXHolder: {fileID: 0}
-  heavyStompVFXHolder: {fileID: 0}
+  heavyAttack:
+    rid: 8001968035020406792
   heavyCollider: {fileID: 7070881340027395658}
   heavyColliderReference: {fileID: 0}
   heavyMuzzle: {fileID: 0}
   needsReloadHeavy: 0
   reloadTimeHeavy: 1
-  chargeVisual: {fileID: 0}
-  heavyChargeVisual: {fileID: 0}
-  heavyAttackHitVFXArray: []
-  heavyAttackForwardSwingVFXArray: []
-  heavyAttackBackwardSwingVFXArray: []
-  heavyAttackDownwardSwingVFXArray: []
-  heavyAttackMissVFXArray: []
-  heavyAttackDefaultVFXArray: []
-  heavyStompVFXArray: []
   heavyAttackHitAudioLibrary: []
   isJointed: 1
   isRightSidedLimb: 0
@@ -942,6 +908,19 @@ MonoBehaviour:
   reelAttackLanded: 0
   myIdleVFX: []
   referencesToIgnore: []
+  references:
+    version: 2
+    RefIds:
+    - rid: 8001968035020406791
+      type: {class: JabNeutral, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
+        Attack: 1
+    - rid: 8001968035020406792
+      type: {class: GrappleHeavy, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
+        Attack: 7
 --- !u!114 &5131103461039801838
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1066,6 +1045,10 @@ MonoBehaviour:
     partRotation: {x: 0, y: 0, z: 0, w: 0}
     partScale: {x: 0, y: 0, z: 0}
     partPosition: {x: 0, y: 0, z: 0}
+    partButton: 0
+    palleteSwapIndex: 
+    partHexCode: 
+    isFlipped: 0
 --- !u!1 &1955327084898914360
 GameObject:
   m_ObjectHideFlags: 0

--- a/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Arms/Arm 6.prefab
+++ b/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Arms/Arm 6.prefab
@@ -1507,7 +1507,7 @@ MonoBehaviour:
   slowedStatusEffect: 0
   grabbedStatusEffect: 0
   neutralAttack:
-    Attack: 1
+    rid: 8001968035020406795
   neutralCollider: {fileID: 2413183929584013590}
   neutralColliderReference: {fileID: 0}
   needsReloadNeutral: 0
@@ -1517,7 +1517,7 @@ MonoBehaviour:
   jabOrSlashLanded: 0
   neutralAttackHitAudioLibrary: []
   heavyAttack:
-    Attack: 6
+    rid: 8001968035020406796
   heavyCollider: {fileID: 8505570850430633742}
   heavyColliderReference: {fileID: 0}
   heavyMuzzle: {fileID: 0}
@@ -1556,6 +1556,19 @@ MonoBehaviour:
   reelAttackLanded: 0
   myIdleVFX: []
   referencesToIgnore: []
+  references:
+    version: 2
+    RefIds:
+    - rid: 8001968035020406795
+      type: {class: JabNeutral, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
+        Attack: 1
+    - rid: 8001968035020406796
+      type: {class: ReelHeavy, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
+        Attack: 6
 --- !u!114 &3175969501913598265
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1698,6 +1711,10 @@ MonoBehaviour:
     partRotation: {x: 0, y: 0, z: 0, w: 0}
     partScale: {x: 0, y: 0, z: 0}
     partPosition: {x: 0, y: 0, z: 0}
+    partButton: 0
+    palleteSwapIndex: 
+    partHexCode: 
+    isFlipped: 0
 --- !u!1 &792572993754259397
 GameObject:
   m_ObjectHideFlags: 0

--- a/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Arms/Arm 7.prefab
+++ b/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Arms/Arm 7.prefab
@@ -44468,7 +44468,7 @@ MonoBehaviour:
   slowedStatusEffect: 0
   grabbedStatusEffect: 0
   neutralAttack:
-    Attack: 2
+    rid: 8001968035020406801
   neutralCollider: {fileID: 0}
   neutralColliderReference: {fileID: 0}
   needsReloadNeutral: 0
@@ -44478,7 +44478,7 @@ MonoBehaviour:
   jabOrSlashLanded: 0
   neutralAttackHitAudioLibrary: []
   heavyAttack:
-    Attack: 2
+    rid: 8001968035020406802
   heavyCollider: {fileID: 0}
   heavyColliderReference: {fileID: 0}
   heavyMuzzle: {fileID: 0}
@@ -44517,6 +44517,19 @@ MonoBehaviour:
   reelAttackLanded: 0
   myIdleVFX: []
   referencesToIgnore: []
+  references:
+    version: 2
+    RefIds:
+    - rid: 8001968035020406801
+      type: {class: JabNeutral, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
+        Attack: 1
+    - rid: 8001968035020406802
+      type: {class: SlashHeavy, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
+        Attack: 2
 --- !u!114 &7191056573203174187
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -44659,6 +44672,10 @@ MonoBehaviour:
     partRotation: {x: 0, y: 0, z: 0, w: 0}
     partScale: {x: 0, y: 0, z: 0}
     partPosition: {x: 0, y: 0, z: 0}
+    partButton: 0
+    palleteSwapIndex: 
+    partHexCode: 
+    isFlipped: 0
 --- !u!1 &6685316956589241367
 GameObject:
   m_ObjectHideFlags: 0

--- a/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Arms/Arm 9.prefab
+++ b/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Arms/Arm 9.prefab
@@ -1507,7 +1507,7 @@ MonoBehaviour:
   slowedStatusEffect: 0
   grabbedStatusEffect: 0
   neutralAttack:
-    Attack: 4
+    rid: 8001968035020406805
   neutralCollider: {fileID: 0}
   neutralColliderReference: {fileID: 0}
   needsReloadNeutral: 0
@@ -1517,7 +1517,7 @@ MonoBehaviour:
   jabOrSlashLanded: 0
   neutralAttackHitAudioLibrary: []
   heavyAttack:
-    Attack: 2
+    rid: 8001968035020406806
   heavyCollider: {fileID: 6798262961518304401}
   heavyColliderReference: {fileID: 0}
   heavyMuzzle: {fileID: 0}
@@ -1556,6 +1556,19 @@ MonoBehaviour:
   reelAttackLanded: 0
   myIdleVFX: []
   referencesToIgnore: []
+  references:
+    version: 2
+    RefIds:
+    - rid: 8001968035020406805
+      type: {class: ProjectileNeutral, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
+        Attack: 4
+    - rid: 8001968035020406806
+      type: {class: SlashHeavy, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
+        Attack: 2
 --- !u!114 &7180194906259602554
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Horns/Horn 1.prefab
+++ b/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Horns/Horn 1.prefab
@@ -161,7 +161,7 @@ MonoBehaviour:
   slowedStatusEffect: 0
   grabbedStatusEffect: 0
   neutralAttack:
-    Attack: 0
+    rid: 8001968035020406823
   neutralCollider: {fileID: 0}
   neutralColliderReference: {fileID: 0}
   needsReloadNeutral: 0
@@ -171,7 +171,7 @@ MonoBehaviour:
   jabOrSlashLanded: 0
   neutralAttackHitAudioLibrary: []
   heavyAttack:
-    Attack: 0
+    rid: 8001968035020406824
   heavyCollider: {fileID: 0}
   heavyColliderReference: {fileID: 0}
   heavyMuzzle: {fileID: 0}
@@ -210,6 +210,19 @@ MonoBehaviour:
   reelAttackLanded: 0
   myIdleVFX: []
   referencesToIgnore: []
+  references:
+    version: 2
+    RefIds:
+    - rid: 8001968035020406823
+      type: {class: ProjectileNeutral, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
+        Attack: 4
+    - rid: 8001968035020406824
+      type: {class: SprayHeavy, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
+        Attack: 3
 --- !u!114 &7107700354215205703
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -334,6 +347,10 @@ MonoBehaviour:
     partRotation: {x: 0, y: 0, z: 0, w: 0}
     partScale: {x: 0, y: 0, z: 0}
     partPosition: {x: 0, y: 0, z: 0}
+    partButton: 0
+    palleteSwapIndex: 
+    partHexCode: 
+    isFlipped: 0
 --- !u!1 &8980360258928122353
 GameObject:
   m_ObjectHideFlags: 0

--- a/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Horns/Horn 3.prefab
+++ b/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Horns/Horn 3.prefab
@@ -9995,7 +9995,7 @@ MonoBehaviour:
   slowedStatusEffect: 0
   grabbedStatusEffect: 0
   neutralAttack:
-    Attack: 4
+    rid: 8001968035020406831
   neutralCollider: {fileID: 0}
   neutralColliderReference: {fileID: 0}
   needsReloadNeutral: 0
@@ -10005,7 +10005,7 @@ MonoBehaviour:
   jabOrSlashLanded: 0
   neutralAttackHitAudioLibrary: []
   heavyAttack:
-    Attack: 3
+    rid: 8001968035020406832
   heavyCollider: {fileID: 0}
   heavyColliderReference: {fileID: 0}
   heavyMuzzle: {fileID: 0}
@@ -10044,6 +10044,19 @@ MonoBehaviour:
   reelAttackLanded: 0
   myIdleVFX: []
   referencesToIgnore: []
+  references:
+    version: 2
+    RefIds:
+    - rid: 8001968035020406831
+      type: {class: ProjectileNeutral, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
+        Attack: 4
+    - rid: 8001968035020406832
+      type: {class: SprayHeavy, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
+        Attack: 3
 --- !u!114 &8180620608210977453
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -10206,6 +10219,10 @@ MonoBehaviour:
     partRotation: {x: 0, y: 0, z: 0, w: 0}
     partScale: {x: 0, y: 0, z: 0}
     partPosition: {x: 0, y: 0, z: 0}
+    partButton: 0
+    palleteSwapIndex: 
+    partHexCode: 
+    isFlipped: 0
 --- !u!1 &6150015877810355158
 GameObject:
   m_ObjectHideFlags: 0

--- a/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Horns/Horn5.prefab
+++ b/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Horns/Horn5.prefab
@@ -1956,7 +1956,7 @@ MonoBehaviour:
   slowedStatusEffect: 0
   grabbedStatusEffect: 0
   neutralAttack:
-    Attack: 0
+    rid: 8001968035020406835
   neutralCollider: {fileID: 0}
   neutralColliderReference: {fileID: 0}
   needsReloadNeutral: 0
@@ -1966,7 +1966,7 @@ MonoBehaviour:
   jabOrSlashLanded: 0
   neutralAttackHitAudioLibrary: []
   heavyAttack:
-    Attack: 0
+    rid: 8001968035020406834
   heavyCollider: {fileID: 0}
   heavyColliderReference: {fileID: 0}
   heavyMuzzle: {fileID: 0}
@@ -2005,6 +2005,19 @@ MonoBehaviour:
   reelAttackLanded: 0
   myIdleVFX: []
   referencesToIgnore: []
+  references:
+    version: 2
+    RefIds:
+    - rid: 8001968035020406834
+      type: {class: HeavyAttack, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
+        Attack: 0
+    - rid: 8001968035020406835
+      type: {class: ProjectileNeutral, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
+        Attack: 4
 --- !u!114 &5285885074470929418
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2129,6 +2142,10 @@ MonoBehaviour:
     partRotation: {x: 0, y: 0, z: 0, w: 0}
     partScale: {x: 0, y: 0, z: 0}
     partPosition: {x: 0, y: 0, z: 0}
+    partButton: 0
+    palleteSwapIndex: 
+    partHexCode: 
+    isFlipped: 0
 --- !u!1 &6394107416342887513
 GameObject:
   m_ObjectHideFlags: 0

--- a/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Legs/Leg 1.prefab
+++ b/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Legs/Leg 1.prefab
@@ -1156,7 +1156,7 @@ MonoBehaviour:
   slowedStatusEffect: 0
   grabbedStatusEffect: 0
   neutralAttack:
-    Attack: 1
+    rid: 8001968035020406838
   neutralCollider: {fileID: 8024796071746726467}
   neutralColliderReference: {fileID: 0}
   needsReloadNeutral: 0
@@ -1166,7 +1166,7 @@ MonoBehaviour:
   jabOrSlashLanded: 0
   neutralAttackHitAudioLibrary: []
   heavyAttack:
-    Attack: 1
+    rid: 8001968035020406840
   heavyCollider: {fileID: 8024796071746726467}
   heavyColliderReference: {fileID: 0}
   heavyMuzzle: {fileID: 0}
@@ -1205,6 +1205,19 @@ MonoBehaviour:
   reelAttackLanded: 0
   myIdleVFX: []
   referencesToIgnore: []
+  references:
+    version: 2
+    RefIds:
+    - rid: 8001968035020406838
+      type: {class: JabNeutral, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
+        Attack: 1
+    - rid: 8001968035020406840
+      type: {class: JabHeavy, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
+        Attack: 1
 --- !u!114 &5215025874775062166
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1329,6 +1342,10 @@ MonoBehaviour:
     partRotation: {x: 0, y: 0, z: 0, w: 0}
     partScale: {x: 0, y: 0, z: 0}
     partPosition: {x: 0, y: 0, z: 0}
+    partButton: 0
+    palleteSwapIndex: 
+    partHexCode: 
+    isFlipped: 0
 --- !u!1 &8024796071838776284
 GameObject:
   m_ObjectHideFlags: 0

--- a/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Legs/Leg 2.prefab
+++ b/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Legs/Leg 2.prefab
@@ -62140,7 +62140,7 @@ MonoBehaviour:
   slowedStatusEffect: 0
   grabbedStatusEffect: 0
   neutralAttack:
-    Attack: 3
+    rid: 8001968035020406843
   neutralCollider: {fileID: 0}
   neutralColliderReference: {fileID: 0}
   needsReloadNeutral: 0
@@ -62150,7 +62150,7 @@ MonoBehaviour:
   jabOrSlashLanded: 0
   neutralAttackHitAudioLibrary: []
   heavyAttack:
-    Attack: 8
+    rid: 8001968035020406844
   heavyCollider: {fileID: 0}
   heavyColliderReference: {fileID: 0}
   heavyMuzzle: {fileID: 0}
@@ -62189,6 +62189,19 @@ MonoBehaviour:
   reelAttackLanded: 0
   myIdleVFX: []
   referencesToIgnore: []
+  references:
+    version: 2
+    RefIds:
+    - rid: 8001968035020406843
+      type: {class: SprayNeutral, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
+        Attack: 3
+    - rid: 8001968035020406844
+      type: {class: BoomerangHeavy, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
+        Attack: 8
 --- !u!114 &2366538475660017173
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -62331,6 +62344,10 @@ MonoBehaviour:
     partRotation: {x: 0, y: 0, z: 0, w: 0}
     partScale: {x: 0, y: 0, z: 0}
     partPosition: {x: 0, y: 0, z: 0}
+    partButton: 0
+    palleteSwapIndex: 
+    partHexCode: 
+    isFlipped: 0
 --- !u!1 &7807970227532851584
 GameObject:
   m_ObjectHideFlags: 0

--- a/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Legs/Leg 6.prefab
+++ b/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Legs/Leg 6.prefab
@@ -2043,7 +2043,7 @@ MonoBehaviour:
   slowedStatusEffect: 0
   grabbedStatusEffect: 0
   neutralAttack:
-    Attack: 0
+    rid: 8001968035020406851
   neutralCollider: {fileID: 0}
   neutralColliderReference: {fileID: 0}
   needsReloadNeutral: 0
@@ -2053,7 +2053,7 @@ MonoBehaviour:
   jabOrSlashLanded: 0
   neutralAttackHitAudioLibrary: []
   heavyAttack:
-    Attack: 0
+    rid: 8001968035020406852
   heavyCollider: {fileID: 0}
   heavyColliderReference: {fileID: 0}
   heavyMuzzle: {fileID: 0}
@@ -2092,6 +2092,19 @@ MonoBehaviour:
   reelAttackLanded: 0
   myIdleVFX: []
   referencesToIgnore: []
+  references:
+    version: 2
+    RefIds:
+    - rid: 8001968035020406851
+      type: {class: SprayNeutral, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
+        Attack: 3
+    - rid: 8001968035020406852
+      type: {class: JabHeavy, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
+        Attack: 1
 --- !u!114 &7427702874014871051
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2234,6 +2247,10 @@ MonoBehaviour:
     partRotation: {x: 0, y: 0, z: 0, w: 0}
     partScale: {x: 0, y: 0, z: 0}
     partPosition: {x: 0, y: 0, z: 0}
+    partButton: 0
+    palleteSwapIndex: 
+    partHexCode: 
+    isFlipped: 0
 --- !u!1 &8783508600480021488
 GameObject:
   m_ObjectHideFlags: 0

--- a/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Legs/Leg 7.prefab
+++ b/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Legs/Leg 7.prefab
@@ -1142,7 +1142,7 @@ MonoBehaviour:
   slowedStatusEffect: 0
   grabbedStatusEffect: 0
   neutralAttack:
-    Attack: 0
+    rid: 8001968035020406855
   neutralCollider: {fileID: 0}
   neutralColliderReference: {fileID: 0}
   needsReloadNeutral: 0
@@ -1152,7 +1152,7 @@ MonoBehaviour:
   jabOrSlashLanded: 0
   neutralAttackHitAudioLibrary: []
   heavyAttack:
-    Attack: 0
+    rid: 8001968035020406856
   heavyCollider: {fileID: 0}
   heavyColliderReference: {fileID: 0}
   heavyMuzzle: {fileID: 0}
@@ -1191,6 +1191,19 @@ MonoBehaviour:
   reelAttackLanded: 0
   myIdleVFX: []
   referencesToIgnore: []
+  references:
+    version: 2
+    RefIds:
+    - rid: 8001968035020406855
+      type: {class: NeutralAttack, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
+        Attack: 10
+    - rid: 8001968035020406856
+      type: {class: HeavyAttack, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
+        Attack: 20
 --- !u!114 &775117722985261561
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1315,6 +1328,10 @@ MonoBehaviour:
     partRotation: {x: 0, y: 0, z: 0, w: 0}
     partScale: {x: 0, y: 0, z: 0}
     partPosition: {x: 0, y: 0, z: 0}
+    partButton: 0
+    palleteSwapIndex: 
+    partHexCode: 
+    isFlipped: 0
 --- !u!1 &7477368032323256738
 GameObject:
   m_ObjectHideFlags: 0

--- a/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Legs/Leg 9.prefab
+++ b/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Legs/Leg 9.prefab
@@ -318,7 +318,7 @@ MonoBehaviour:
   slowedStatusEffect: 0
   grabbedStatusEffect: 0
   neutralAttack:
-    Attack: 0
+    rid: 8001968035020406859
   neutralCollider: {fileID: 0}
   neutralColliderReference: {fileID: 0}
   needsReloadNeutral: 0
@@ -328,7 +328,7 @@ MonoBehaviour:
   jabOrSlashLanded: 0
   neutralAttackHitAudioLibrary: []
   heavyAttack:
-    Attack: 0
+    rid: 8001968035020406860
   heavyCollider: {fileID: 0}
   heavyColliderReference: {fileID: 0}
   heavyMuzzle: {fileID: 0}
@@ -367,6 +367,19 @@ MonoBehaviour:
   reelAttackLanded: 0
   myIdleVFX: []
   referencesToIgnore: []
+  references:
+    version: 2
+    RefIds:
+    - rid: 8001968035020406859
+      type: {class: JabNeutral, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
+        Attack: 1
+    - rid: 8001968035020406860
+      type: {class: GrappleHeavy, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
+        Attack: 7
 --- !u!114 &7306861082688536980
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -509,6 +522,10 @@ MonoBehaviour:
     partRotation: {x: 0, y: 0, z: 0, w: 0}
     partScale: {x: 0, y: 0, z: 0}
     partPosition: {x: 0, y: 0, z: 0}
+    partButton: 0
+    palleteSwapIndex: 
+    partHexCode: 
+    isFlipped: 0
 --- !u!1 &3542689408206646289
 GameObject:
   m_ObjectHideFlags: 0

--- a/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Mouths/Mouth 2.prefab
+++ b/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Mouths/Mouth 2.prefab
@@ -526,7 +526,7 @@ MonoBehaviour:
   slowedStatusEffect: 0
   grabbedStatusEffect: 0
   neutralAttack:
-    Attack: 4
+    rid: 8001968035020406863
   neutralCollider: {fileID: 0}
   neutralColliderReference: {fileID: 0}
   needsReloadNeutral: 0
@@ -536,7 +536,7 @@ MonoBehaviour:
   jabOrSlashLanded: 0
   neutralAttackHitAudioLibrary: []
   heavyAttack:
-    Attack: 4
+    rid: 8001968035020406864
   heavyCollider: {fileID: 0}
   heavyColliderReference: {fileID: 0}
   heavyMuzzle: {fileID: 0}
@@ -575,6 +575,19 @@ MonoBehaviour:
   reelAttackLanded: 0
   myIdleVFX: []
   referencesToIgnore: []
+  references:
+    version: 2
+    RefIds:
+    - rid: 8001968035020406863
+      type: {class: ProjectileNeutral, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
+        Attack: 4
+    - rid: 8001968035020406864
+      type: {class: HeavyAttack, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
+        Attack: 12
 --- !u!114 &5863467593907076767
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -717,6 +730,10 @@ MonoBehaviour:
     partRotation: {x: 0, y: 0, z: 0, w: 0}
     partScale: {x: 0, y: 0, z: 0}
     partPosition: {x: 0, y: 0, z: 0}
+    partButton: 0
+    palleteSwapIndex: 
+    partHexCode: 
+    isFlipped: 0
 --- !u!1 &2944404956106150536
 GameObject:
   m_ObjectHideFlags: 0

--- a/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Mouths/Mouth 5.prefab
+++ b/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Mouths/Mouth 5.prefab
@@ -405,7 +405,7 @@ MonoBehaviour:
   slowedStatusEffect: 0
   grabbedStatusEffect: 0
   neutralAttack:
-    Attack: 1
+    rid: 8001968035020406867
   neutralCollider: {fileID: 8982890768280038793}
   neutralColliderReference: {fileID: 0}
   needsReloadNeutral: 0
@@ -415,7 +415,7 @@ MonoBehaviour:
   jabOrSlashLanded: 0
   neutralAttackHitAudioLibrary: []
   heavyAttack:
-    Attack: 1
+    rid: 8001968035020406868
   heavyCollider: {fileID: 8982890768280038793}
   heavyColliderReference: {fileID: 0}
   heavyMuzzle: {fileID: 0}
@@ -454,6 +454,19 @@ MonoBehaviour:
   reelAttackLanded: 0
   myIdleVFX: []
   referencesToIgnore: []
+  references:
+    version: 2
+    RefIds:
+    - rid: 8001968035020406867
+      type: {class: SprayNeutral, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
+        Attack: 3
+    - rid: 8001968035020406868
+      type: {class: HeavyAttack, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
+        Attack: 18
 --- !u!114 &3985189302008755475
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -596,6 +609,10 @@ MonoBehaviour:
     partRotation: {x: 0, y: 0, z: 0, w: 0}
     partScale: {x: 0, y: 0, z: 0}
     partPosition: {x: 0, y: 0, z: 0}
+    partButton: 0
+    palleteSwapIndex: 
+    partHexCode: 
+    isFlipped: 0
 --- !u!1 &8982890766923249346
 GameObject:
   m_ObjectHideFlags: 0

--- a/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Tails/Tail 7.prefab
+++ b/Monster Mash/Monster Mash/Assets/Resources/Build-A-Scare Parts/Tails/Tail 7.prefab
@@ -558,7 +558,7 @@ MonoBehaviour:
   slowedStatusEffect: 0
   grabbedStatusEffect: 0
   neutralAttack:
-    Attack: 0
+    rid: 8001968035020406871
   neutralCollider: {fileID: 0}
   neutralColliderReference: {fileID: 0}
   needsReloadNeutral: 0
@@ -568,7 +568,7 @@ MonoBehaviour:
   jabOrSlashLanded: 0
   neutralAttackHitAudioLibrary: []
   heavyAttack:
-    Attack: 0
+    rid: 8001968035020406872
   heavyCollider: {fileID: 0}
   heavyColliderReference: {fileID: 0}
   heavyMuzzle: {fileID: 0}
@@ -607,6 +607,19 @@ MonoBehaviour:
   reelAttackLanded: 0
   myIdleVFX: []
   referencesToIgnore: []
+  references:
+    version: 2
+    RefIds:
+    - rid: 8001968035020406871
+      type: {class: SlashNeutral, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
+        Attack: 2
+    - rid: 8001968035020406872
+      type: {class: HeavyAttack, ns: , asm: Assembly-CSharp}
+      data:
+        movementModifier: {x: 0, y: 0}
+        Attack: 19
 --- !u!114 &8205021909025256439
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -731,6 +744,10 @@ MonoBehaviour:
     partRotation: {x: 0, y: 0, z: 0, w: 0}
     partScale: {x: 0, y: 0, z: 0}
     partPosition: {x: 0, y: 0, z: 0}
+    partButton: 0
+    palleteSwapIndex: 
+    partHexCode: 
+    isFlipped: 0
 --- !u!1 &3001473753191841852
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Added a vector 2 movement modifier to the attacks which adds movement to the player when the part attacks. Also made an upgrade to the monster part script where when you select the attack enum it reassigns the neutral and heavy attack vars in the editor. This allows us to set vars that belong to the attack classes in the inspector which was needed to make setting the movement modifier simple.