### PR TITLE
Fixed legs animating together 

### DIFF
--- a/Monster Mash/Monster Mash/Assets/Monster Parts/MonsterCalculations.cs
+++ b/Monster Mash/Monster Mash/Assets/Monster Parts/MonsterCalculations.cs
@@ -53,6 +53,20 @@ public class MonsterCalculations
                 }
             }
         }
+
+        bool partConnectedToLeftLower = (part.connectionPoint & MonsterPartConnectionPoint.LeftLowerTorsoConnection) == 
+            MonsterPartConnectionPoint.LeftLowerTorsoConnection;
+        bool partConnectedToRightLower = (part.connectionPoint & MonsterPartConnectionPoint.RightLowerTorsoConnection) ==
+            MonsterPartConnectionPoint.RightLowerTorsoConnection;
+
+        if (partConnectedToLeftLower)
+        {
+            part.isLeftSidedLimb = true;
+        }
+        else if (partConnectedToRightLower)
+        {
+            part.isRightSidedLimb = true;
+        }
     }
 
     private void ApplyConfig(AttackConfig config)

--- a/Monster Mash/Monster Mash/Assets/Monster Parts/NewMonsterPart.cs
+++ b/Monster Mash/Monster Mash/Assets/Monster Parts/NewMonsterPart.cs
@@ -31,11 +31,9 @@ public class NewMonsterPart : MonoBehaviour
 #if UNITY_EDITOR
     void OnValidate()
     {
-        if (neutralAttack == null)
-            neutralAttack = new NeutralAttack();
+        neutralAttack ??= new NeutralAttack();
 
-        if (heavyAttack == null)
-            heavyAttack = new HeavyAttack();
+        heavyAttack ??= new HeavyAttack();
     }
 #endif
    [Header("Monster Part Questionaire")]


### PR DESCRIPTION
Fixed an issue where both grounded legs on a monster were animating in sync. The left and right sided bools on the monster part were not being set so to fix the issue I set them in monster calculations. 